### PR TITLE
add missing star in zone jsdoc

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-/*
+/**
  * Suppress closure compiler errors about unknown 'global' variable
  * @fileoverview
  * @suppress {undefinedVars}


### PR DESCRIPTION
Without this extra star, the Closure commands in the jsdoc are ignored.